### PR TITLE
Enable interface parsing functions to compute predictive kernels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,36 @@
 .DS_Store
+
+# History files
+.Rhistory
+.Rapp.history
+/*/.Rhistory
+
+# Session Data files
+.RData
+
+# Example code in package build process
+*-Ex.R
+
+# Output files from R CMD build
+/*.tar.gz
+
+# Output files from R CMD check
+/*.Rcheck/
+
+# RStudio files
+.Rproj.user/
+
+# produced vignettes
+vignettes/*.html
+vignettes/*.pdf
+
+# OAuth2 token, see https://github.com/hadley/httr/releases/tag/v0.3
+.httr-oauth
+
+# knitr and R markdown default cache directories
+/*_cache/
+/cache/
+
+# Temporary files created by R markdown
+*.utf8.md
+*.knit.md

--- a/man/parse_cvek_formula.Rd
+++ b/man/parse_cvek_formula.Rd
@@ -4,7 +4,8 @@
 \alias{parse_cvek_formula}
 \title{Parses user-supplied formula to fixed-effect and kernel matrices.}
 \usage{
-parse_cvek_formula(formula, kern_func_list, data, verbose = FALSE)
+parse_cvek_formula(formula, kern_func_list, data, data_new = NULL,
+  verbose = FALSE)
 }
 \arguments{
 \item{formula}{(formula) A user-supplied formula.}
@@ -14,6 +15,8 @@ parse_cvek_formula(formula, kern_func_list, data, verbose = FALSE)
 \item{data}{(data.frame, n*d) a data.frame, list or environment (or object
 coercible by as.data.frame to a data.frame), containing the variables in
 formula. Neither a matrix nor an array will be accepted.}
+
+\item{data_new}{(data.frame, n_new*d) new data for computing predictions.}
 
 \item{verbose}{(logical) Whether to print additional messages.}
 }
@@ -41,6 +44,8 @@ and exclude interaction term by including -1 on the rhs of formula.
 # create data
 data <- as.data.frame(matrix(rnorm(700), ncol = 7,
 dimnames = list(NULL, paste0("x", 1:7))))
+data_new <- as.data.frame(matrix(rexp(700), ncol = 7,
+dimnames = list(NULL, paste0("x", 1:7))))
 data$y <- as.matrix(data) \%*\% rnorm(7)
 formula <- y ~ x1 + x2 + k(x3, x4) + k(x5, x6) + k(x7) + k(x3, x4) * k(x5, x6) * x7
 kern_par <- data.frame(method = c("rbf", "polynomial", "matern"),
@@ -53,7 +58,8 @@ kern_func_list[[d]] <- generate_kernel(kern_par[d,]$method,
 kern_par[d,]$l, kern_par[d,]$d)
 }
 
-parse_cvek_formula(formula, kern_func_list = kern_func_list, data = data)
+parse_cvek_formula(formula, kern_func_list = kern_func_list, 
+data = data, data_new = data_new)
 
 }
 \author{

--- a/man/parse_kernel_terms.Rd
+++ b/man/parse_kernel_terms.Rd
@@ -4,7 +4,7 @@
 \alias{parse_kernel_terms}
 \title{Computes kernel matrix for each kernel term in the formula}
 \usage{
-parse_kernel_terms(kern_effect_formula, kern_func, data)
+parse_kernel_terms(kern_effect_formula, kern_func, data, data_new = NULL)
 }
 \arguments{
 \item{kern_effect_formula}{(character) a term in the formula}
@@ -15,6 +15,8 @@ kernel if the variable doesn't contain 'k()'}
 \item{data}{(data.frame, n*d) a data.frame, list or environment (or object
 coercible by as.data.frame to a data.frame), containing the variables in
 formula. Neither a matrix nor an array will be accepted.}
+
+\item{data_new}{(data.frame, n_new*d) new data for computing predictions.}
 }
 \value{
 A list of kernel matrices for each term in the formula

--- a/man/parse_kernel_variable.Rd
+++ b/man/parse_kernel_variable.Rd
@@ -4,7 +4,7 @@
 \alias{parse_kernel_variable}
 \title{Creates kernel matrix for each variable in the formula}
 \usage{
-parse_kernel_variable(kern_var_name, kern_func, data)
+parse_kernel_variable(kern_var_name, kern_func, data, data_new = NULL)
 }
 \arguments{
 \item{kern_var_name}{(vector of characters) Names of variables in data to
@@ -18,6 +18,8 @@ kernel if the variable doesn't contain 'k()'}
 \item{data}{(data.frame, n*d) a data.frame, list or environment (or object
 coercible by as.data.frame to a data.frame), containing the variables in
 formula. Neither a matrix nor an array will be accepted.}
+
+\item{data_new}{(data.frame, n_new*d) new data for computing predictions.}
 }
 \value{
 The n*n kernel matrix corresponding to the variable being computed.

--- a/tests/testthat/helper_test_interface.R
+++ b/tests/testthat/helper_test_interface.R
@@ -17,7 +17,13 @@ setup_kernel_lib <- function(){
 }
 
 # helper function for computing kernel matrix
-compute_expected_matrix <- function(term_names, kern_func, data) {
+compute_expected_matrix <- function(term_names, kern_func, data, data_new = NULL) {
   data_mat <- as.matrix(data[, term_names, drop = FALSE])
-  kern_func(data_mat, data_mat)
+  
+  data_mat_new <- data_mat
+  if (!is.null(data_new)){
+    data_mat_new <- as.matrix(data_new[, term_names, drop = FALSE])
+  }
+  
+  kern_func(data_mat_new, data_mat)
 }

--- a/tests/testthat/test_interface.R
+++ b/tests/testthat/test_interface.R
@@ -10,6 +10,11 @@ data <- as.data.frame(matrix(
 ))
 data$y <- as.matrix(data) %*% rnorm(d)
 
+data_new <- as.data.frame(matrix(
+  rexp(n * d),
+  ncol = d,
+  dimnames = list(NULL, paste0("x", 1:d))
+))
 
 test_that(desc = "parse_kernel_variable computes kernel effects",
           code = {
@@ -30,6 +35,31 @@ test_that(desc = "parse_kernel_variable computes kernel effects",
               parse_kernel_variable("x4", rbf_kern_func, data)
             fixd_effect_mat_expected <-
               compute_expected_matrix("x4", lnr_kern_func, data)
+            
+            expect_identical(kern_effect_mat_singl, kern_effect_mat_singl_expected)
+            expect_identical(kern_effect_mat_multi, kern_effect_mat_multi_expected)
+            expect_identical(fixd_effect_mat, fixd_effect_mat_expected)
+          })
+
+test_that(desc = "parse_kernel_variable computes predictive kernel",
+          code = {
+            rbf_kern_func <- generate_kernel(method = "rbf", l = 1)
+            lnr_kern_func <- generate_kernel(method = "linear")
+            
+            kern_effect_mat_singl <-
+              parse_kernel_variable("k(x1)", rbf_kern_func, data, data_new)
+            kern_effect_mat_singl_expected <-
+              compute_expected_matrix("x1", rbf_kern_func, data, data_new)
+            
+            kern_effect_mat_multi <-
+              parse_kernel_variable("k(x5,x7,x3)", rbf_kern_func, data, data_new)
+            kern_effect_mat_multi_expected <-
+              compute_expected_matrix(c("x5", "x7", "x3"), rbf_kern_func, data, data_new)
+            
+            fixd_effect_mat <-
+              parse_kernel_variable("x4", rbf_kern_func, data, data_new)
+            fixd_effect_mat_expected <-
+              compute_expected_matrix("x4", lnr_kern_func, data, data_new)
             
             expect_identical(kern_effect_mat_singl, kern_effect_mat_singl_expected)
             expect_identical(kern_effect_mat_multi, kern_effect_mat_multi_expected)


### PR DESCRIPTION
Updated the parsing functions `parse_cvek_formula` and their utility functions (`parse_kernel_terms` `parse_kernel_variable`) to allow computation of the predictive kernels.

One new test case added to `tests/testthat/test_interface.R`. 

All check passed. 
[00check.log](https://github.com/statmlhb/CVEK/files/2857926/00check.log)
