### PR TITLE
corrected fixed-effect output for parse_cvek_fomula

### DIFF
--- a/R/interface.R
+++ b/R/interface.R
@@ -250,6 +250,11 @@ cvek_test <- function(est_res,
 #' kern_par[d,]$l, kern_par[d,]$d)
 #' }
 #'
+#' # produce training data 
+#' parse_cvek_formula(formula, kern_func_list = kern_func_list, 
+#' data = data, data_new = NULL)
+#' 
+#' # produce prediction data from data_new
 #' parse_cvek_formula(formula, kern_func_list = kern_func_list, 
 #' data = data, data_new = data_new)
 #'
@@ -265,7 +270,7 @@ parse_cvek_formula <-
     # extract indep variables and intercept
     intercept <- attr(tf, "intercept")
     response_vector <- NULL
-    if (attr(tf, "response") > 0) {
+    if ((attr(tf, "response") > 0) & is.null(data_new)) {
       response_name <- as.character(attr(tf, "variables")[2])
       response_vector <- data[, response_name]
     }
@@ -312,8 +317,13 @@ parse_cvek_formula <-
     # produce fixed-effect matrix X using model.frame
     fixed_effect_matrix <- NULL
     if (!is.null(fixed_effect_formula)) {
+      fixed_effect_data <- data
+      if (!is.null(data_new)){
+        fixed_effect_data <- data_new
+      }
+      
       fixed_effect_matrix <-
-        model.matrix(fixed_effect_formula, data = data)
+        model.matrix(fixed_effect_formula, data = fixed_effect_data)
     }
     
     # produce kernel-effect matrices Ks

--- a/man/parse_cvek_formula.Rd
+++ b/man/parse_cvek_formula.Rd
@@ -58,6 +58,11 @@ kern_func_list[[d]] <- generate_kernel(kern_par[d,]$method,
 kern_par[d,]$l, kern_par[d,]$d)
 }
 
+# produce training data 
+parse_cvek_formula(formula, kern_func_list = kern_func_list, 
+data = data, data_new = NULL)
+
+# produce prediction data from data_new
 parse_cvek_formula(formula, kern_func_list = kern_func_list, 
 data = data, data_new = data_new)
 

--- a/tests/testthat/test_interface.R
+++ b/tests/testthat/test_interface.R
@@ -41,6 +41,7 @@ test_that(desc = "parse_kernel_variable computes kernel effects",
             expect_identical(fixd_effect_mat, fixd_effect_mat_expected)
           })
 
+
 test_that(desc = "parse_kernel_variable computes predictive kernel",
           code = {
             rbf_kern_func <- generate_kernel(method = "rbf", l = 1)
@@ -155,5 +156,19 @@ test_that(desc = "parse_cvek_formula with no intercept term",
              expect_equal(model_mat_list$X, 
                           model.matrix(~1, data = data))
              
+           })
+ 
+ test_that(desc = "parse_cvek_formula predict fixed effect",
+           code = {
+             formula <- y ~ x1 + x2 + x5*x7
+             formula_new <- ~ x1 + x2 + x5*x7
+             
+             kern_func_list <- setup_kernel_lib()
+             
+             model_mat_list <- parse_cvek_formula(formula, kern_func_list, 
+                                                  data, data_new)
+             expect_equal(model_mat_list$X, 
+                          model.matrix(formula_new, data = data_new))
+             expect_equal(model_mat_list$y, NULL)
            })
  


### PR DESCRIPTION
In `parse_cvek_formula`, when `data_new` is not `NULL`, changed `res_list$X` to fixed effect matrix from `data_new`, and changed `res_list$y` to `NULL`.

Test case for this scenario is added. All test pass.
[00check.log](https://github.com/statmlhb/CVEK/files/2862898/00check.log)
